### PR TITLE
Query refactor

### DIFF
--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ const searchForVineyard = (req, res, next) => {
         } else if (name !== '') {
           matchingVineyards = filterByQueryParam(vineyards, 'name', name)
         } else {
-          res.status(422).json({ message: 'Invalid query parameter(s). You may search by "name" or "region" only.' })
+          res.status(400).json({ message: 'Invalid query parameter(s). You may search by "name" or "region" only.' })
         }
 
         matchingVineyards.length

--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ const searchForVineyard = (req, res, next) => {
         } else if (name !== '') {
           matchingVineyards = filterByQueryParam(vineyards, 'name', name)
         } else {
-          res.status(400).json({ message: 'Invalid query parameter(s). You may search by "name" or "region" only.' })
+          return res.status(400).json({ message: 'Invalid query parameter(s). You may search by "name" or "region" only.' })
         }
 
         matchingVineyards.length

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ app.get('/', (request, response) => {
   response.status(200).json({message: 'NC Vineyards'})
 })
 
-const queryFilter = (vineyards, filter, search) => {
+const filterByQueryParam = (vineyards, filter, search) => {
   return vineyards.filter(vineyard => {
     return vineyard[filter].toLowerCase().includes(search.toLowerCase()) ||
       search.toLowerCase().includes(vineyard[filter].toLowerCase())
@@ -37,9 +37,9 @@ const searchForVineyard = (req, res, next) => {
     database('vineyards').select()
       .then(vineyards => {
         if (region !== '') {
-          matchingVineyards = queryFilter(vineyards, 'region', region)
+          matchingVineyards = filterByQueryParam(vineyards, 'region', region)
         } else if (name !== '') {
-          matchingVineyards = queryFilter(vineyards, 'name', name)
+          matchingVineyards = filterByQueryParam(vineyards, 'name', name)
         } else {
           res.status(422).json({ message: 'Invalid query parameter(s). You may search by "name" or "region" only.' })
         }
@@ -54,17 +54,16 @@ const searchForVineyard = (req, res, next) => {
   } else {
     next()
   }
- 
 }
 
 app.get('/api/v1/vineyards', searchForVineyard, (request, response) => {
-    database('vineyards').select()
-      .then(vineyards => {
-        response.status(200).json(vineyards);
-      })
-      .catch(error => {
-        response.status(500).json(`Error retrieving data: ${error}`)
-      })
+  database('vineyards').select()
+    .then(vineyards => {
+      response.status(200).json(vineyards);
+    })
+    .catch(error => {
+      response.status(500).json(`Error retrieving data: ${error}`)
+    })
 });
 
 app.get('/api/v1/vineyards/:id', (request, response) => {

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -139,6 +139,19 @@ describe('API Routes for vineyards', () => {
         })
     })
 
+    it('should return an error message if a search query parameter is invalid', (done) => {
+      chai.request(server)
+        .get('/api/v1/vineyards?type=malbec')
+        .end((err, response) => {
+          response.should.have.status(400);
+          response.should.be.json;
+          response.should.be.a('object');
+          response.body.should.have.property('message');
+          response.body.message.should.equal(`Invalid query parameter(s). You may search by "name" or "region" only.`)
+          done()
+        })
+    })
+
     it('should return a specific vineyard by id', (done) => {
       chai.request(server)
         .get(`/api/v1/vineyards/1`)

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -134,7 +134,7 @@ describe('API Routes for vineyards', () => {
           response.should.be.json;
           response.should.be.a('object');
           response.body.should.have.property('message');
-          response.body.message.should.equal(`Could not find any resources matching your query (searchable terms are 'region' and 'name').`)
+          response.body.message.should.equal(`Could not find any vineyards matching your query.`)
           done()
         })
     })


### PR DESCRIPTION
References Issues #40 #20 

These changes work on refactoring the logic surrounding handling of query parameters in the `GET '/api/v1/vineyards'` endpoint. Specifically the changes made work to accomplish the following:

- Clean up main endpoint by moving query logic into middleware function `searchForVineyard`
- Add error messaging for invalid query parameter (settled on 400 after a bit of research, but it's still possible there's a more semantically accurate code to use)
- Make filtering for queries more robust, so that users don't need to enter the exact name or region in order to see related results. I added this with the thought that this functionality of the API may likely come into play for user searching on the front-end, so it might be nice to be able to get "related results". But whether or not this is something you want to implement versus having a stricter search is up to you!

There's definitely still a good bit of logic going on in the middleware, which is perhaps hard to avoid given everything that needs to happen for all those checks. Hopefully it is a little cleaner and dryer though. Let me know of any questions/concerns you have with the changes and if there's anything else you would like to see with this refactor and the related functionality.